### PR TITLE
Add SaaS A/B test sample size calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ by Utilizing Pre-Experiment Data (Microsoft)](https://exp-platform.com/Documents
 * [LaunchDarkly](https://launchdarkly.com/features/experimentation/)
 * [JetLab](https://tryjetlab.com/)
 * [GrowthBook](https://www.growthbook.io/)
+* [SaaS A/B Test Sample Size Calculator](https://trial-to-paid-conversion-sample-size-calculator.vercel.app/) - Free browser-only planner for SaaS trial-to-paid A/B test sample size, readout timing, and local Markdown/CSV experiment notes. ([Source Code](https://github.com/Turner-Levey/trial-to-paid-conversion-sample-size-calculator))

--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ by Utilizing Pre-Experiment Data (Microsoft)](https://exp-platform.com/Documents
 * [LaunchDarkly](https://launchdarkly.com/features/experimentation/)
 * [JetLab](https://tryjetlab.com/)
 * [GrowthBook](https://www.growthbook.io/)
-* [SaaS A/B Test Sample Size Calculator](https://trial-to-paid-conversion-sample-size-calculator.vercel.app/) - Free browser-only planner for SaaS trial-to-paid A/B test sample size, readout timing, and local Markdown/CSV experiment notes. ([Source Code](https://github.com/Turner-Levey/trial-to-paid-conversion-sample-size-calculator))
+* [SaaS A/B Test Sample Size Calculator](https://trial-to-paid-conversion-sample-size-calculator.vercel.app/)


### PR DESCRIPTION
Adds one free, browser-only sample-size planning tool to the Tools and Companies section.

Disclosure: I maintain the linked tool and source repository as Turner Levey. The tool is free, open source, no-signup, and runs locally in the browser with no analytics or tracking. It focuses on SaaS trial-to-paid A/B test planning, including sample size, readout timing, and local Markdown/CSV notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Tools and Companies section in the README to include a new SaaS A/B Test Sample Size Calculator, with links to its Vercel deployment and source repository.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DavisTrey/ExperimentationResources/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->